### PR TITLE
fix: early exit when domain is not equal to the powerdns zone

### DIFF
--- a/certbot_dns_pdns/dns_pdns.py
+++ b/certbot_dns_pdns/dns_pdns.py
@@ -62,6 +62,8 @@ class Authenticator(dns_common_lexicon.LexiconDNSAuthenticator):
             hint = "Is your API key correct?"
         if e.response.status_code == 404:
             hint = "Is your server ID correct?"
+            if len(domain_name.split(".")) > 1:
+                return False
 
         hint_disp = f" ({hint})" if hint else ""
 


### PR DESCRIPTION
When you try to create a certificate for a specific host that is not the domain it self you get this error:
_Error determining zone identifier for foo.bar.baz.example.com: '404 Client Error: Not Found for url: http://dns.example.com/api/v1/servers/localhost/zones/foo.bar.baz.example.com.'. (Is your server ID correct?)_

This is because the function __resolve_domain_ defined in class _LexiconDNSAuthenticator_ return the 404 error during the cycle when is checking what are the correct dns zone where to add the TXT challenge record. This seam a normal behaviour of powerdns API.

This fix check if we are at the last iteration of the cycle by evaluate the number of element after split the domain_namy by '.' in this way if we are at the end of the cycle in the list there will be only 1 element, the TLD.
